### PR TITLE
Add likes functionality to main homepage

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -175,7 +175,7 @@ main {
   align-items: center;
 }
 
-.show img {
+.show .show-img {
   width: 100px;
 }
 
@@ -187,4 +187,3 @@ figcaption {
 figcaption .likes {
   font-size: 0.8rem;
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import './index.css';
-import { displayTVShows } from './modules/api-dom';
+import { displayTVShows, displayLikes } from './modules/api-dom';
 
 displayTVShows();
+displayLikes();

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import './index.css';
-import { displayTVShows, displayLikes } from './modules/api-dom';
+import startApp from './modules/api-dom';
+import { postLike } from './modules/involvement-api-helpers';
 
-displayTVShows();
-displayLikes();
+startApp();

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import './index.css';
 import startApp from './modules/api-dom';
-import { postLike } from './modules/involvement-api-helpers';
 
 startApp();

--- a/src/modules/api-dom.js
+++ b/src/modules/api-dom.js
@@ -1,17 +1,16 @@
 import { shows, likes, showEndpoints, involvementEndpoints } from './globals';
 import { getShows } from './shows-api-helpers';
-import { getLikes } from './involvement-api-helpers';
+import { getLikes, postLike } from './involvement-api-helpers';
 
 const mainContainer = document.querySelector('main');
 
-export const setShows = async () => {
+const setShows = async () => {
   const allShows = await getShows(showEndpoints.shows, [1, 5, 7, 3, 6, 9]);
   shows.push(...allShows);
 };
 
-export const displayTVShows = async () => {
+const displayTVShows = async () => {
   await setShows();
-  console.log(shows);
   // create artcile element
   shows.forEach((show, i) => {
     const articleElem = document.createElement('article');
@@ -23,7 +22,7 @@ export const displayTVShows = async () => {
         <figcaption>
           <p>${show.name}</p>
           <p>
-            <span><i class="fa-solid fa-heart"></i></span><br /><span
+            <span class="hearts"><i data-id="${show.id}" class="fa-solid fa-heart"></i></span><br /><span
               class="likes" id="like-${show.id}"
               >5 likes</span
             >
@@ -35,7 +34,7 @@ export const displayTVShows = async () => {
   });
 };
 
-export const displayLikes = async () => {
+const displayLikes = async () => {
   const data = await getLikes(involvementEndpoints.likes);
   likes.push(...data);
   // search containers for their corresponding id and set their value
@@ -45,4 +44,29 @@ export const displayLikes = async () => {
       likeContainer.innerText = `${like.likes} likes`;
     }
   });
+};
+
+const handleLike = async (eve) => {
+  const likeElem = eve.target;
+  const tvShowID = likeElem.dataset.id;
+  await postLike(involvementEndpoints.likes, tvShowID);
+  displayLikes();
+};
+
+const createLikes = async () => {
+  const likesContainers = document.querySelectorAll('.hearts');
+  likesContainers.forEach((likesContainer) => {
+    likesContainer.addEventListener('click', handleLike);
+  });
+};
+
+export default async () => {
+  try {
+    await displayTVShows();
+    displayLikes();
+    createLikes();
+  } catch (error) {
+    return error.message;
+  }
+  return true;
 };

--- a/src/modules/api-dom.js
+++ b/src/modules/api-dom.js
@@ -1,5 +1,6 @@
-import { shows, showEndpoints } from './globals';
+import { shows, likes, showEndpoints, involvementEndpoints } from './globals';
 import { getShows } from './shows-api-helpers';
+import { getLikes } from './involvement-api-helpers';
 
 const mainContainer = document.querySelector('main');
 
@@ -23,7 +24,7 @@ export const displayTVShows = async () => {
           <p>${show.name}</p>
           <p>
             <span><i class="fa-solid fa-heart"></i></span><br /><span
-              class="likes"
+              class="likes" id="like-${show.id}"
               >5 likes</span
             >
           </p>
@@ -31,5 +32,17 @@ export const displayTVShows = async () => {
         <button class="btn" data-id="${i}" type="button">Comments</button>
     `;
     mainContainer.appendChild(articleElem);
+  });
+};
+
+export const displayLikes = async () => {
+  const data = await getLikes(involvementEndpoints.likes);
+  likes.push(...data);
+  // search containers for their corresponding id and set their value
+  likes.forEach((like) => {
+    const likeContainer = document.querySelector(`#like-${like.item_id}`);
+    if (likeContainer) {
+      likeContainer.innerText = `${like.likes} likes`;
+    }
   });
 };

--- a/src/modules/api-dom.js
+++ b/src/modules/api-dom.js
@@ -1,4 +1,6 @@
-import { shows, likes, showEndpoints, involvementEndpoints } from './globals';
+import {
+  shows, likes, showEndpoints, involvementEndpoints,
+} from './globals';
 import { getShows } from './shows-api-helpers';
 import { getLikes, postLike } from './involvement-api-helpers';
 
@@ -17,7 +19,7 @@ const displayTVShows = async () => {
     articleElem.classList.add('show');
     articleElem.innerHTML = `
        <figure>
-          <img src="${show.image.medium}" alt="picture" />
+          <img class="show-img" src="${show.image.medium}" alt="picture" />
         </figure>
         <figcaption>
           <p>${show.name}</p>

--- a/src/modules/globals.js
+++ b/src/modules/globals.js
@@ -1,7 +1,8 @@
 export const shows = [];
+const involvementID = 'kRRjieBzj8pkjFUnklmh';
 
 export const involvmentEndpoints = {
-  base: 'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi',
+  likes: `https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/${involvementID}/likes`,
 };
 
 export const showEndpoints = {

--- a/src/modules/globals.js
+++ b/src/modules/globals.js
@@ -1,7 +1,9 @@
 export const shows = [];
-const involvementID = 'kRRjieBzj8pkjFUnklmh';
+export const likes = [];
+// const involvementID = 'kRRjieBzj8pkjFUnklmh';
+const involvementID = 'LpjkxbOoouO6w5jth5ro';
 
-export const involvmentEndpoints = {
+export const involvementEndpoints = {
   likes: `https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/${involvementID}/likes`,
 };
 

--- a/src/modules/involvement-api-helpers.js
+++ b/src/modules/involvement-api-helpers.js
@@ -1,6 +1,12 @@
-export const getLikes = async (id) => {
+export const getLikes = async (endpoint) => {
+  let data;
   try {
-  } catch (error) {}
+    const response = await fetch(endpoint);
+    data = await response.json();
+  } catch (error) {
+    return error.message;
+  }
+  return data;
 };
 
 export const getComments = async (id) => {
@@ -8,9 +14,17 @@ export const getComments = async (id) => {
   } catch (error) {}
 };
 
-export const postLike = async (id) => {
+export const postLike = async (endpoint, id) => {
+  let response;
   try {
-  } catch (error) {}
+    response = await fetch(endpoint, {
+      method: 'POST',
+      body: JSON.stringify({ item_id: id }),
+    });
+  } catch (error) {
+    return error.message;
+  }
+  return response.ok;
 };
 
 export const postComment = async (id) => {

--- a/src/modules/involvement-api-helpers.js
+++ b/src/modules/involvement-api-helpers.js
@@ -19,7 +19,12 @@ export const postLike = async (endpoint, id) => {
   try {
     response = await fetch(endpoint, {
       method: 'POST',
-      body: JSON.stringify({ item_id: id }),
+      body: JSON.stringify({
+        item_id: id,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
     });
   } catch (error) {
     return error.message;

--- a/src/modules/involvement-api-helpers.js
+++ b/src/modules/involvement-api-helpers.js
@@ -9,10 +9,10 @@ export const getLikes = async (endpoint) => {
   return data;
 };
 
-export const getComments = async (id) => {
-  try {
-  } catch (error) {}
-};
+// export const getComments = async (id) => {
+//   try {
+//   } catch (error) {}
+// };
 
 export const postLike = async (endpoint, id) => {
   let response;
@@ -32,7 +32,7 @@ export const postLike = async (endpoint, id) => {
   return response.ok;
 };
 
-export const postComment = async (id) => {
-  try {
-  } catch (error) {}
-};
+// export const postComment = async (id) => {
+//   try {
+//   } catch (error) {}
+// };

--- a/src/modules/shows-api-helpers.js
+++ b/src/modules/shows-api-helpers.js
@@ -1,9 +1,7 @@
 export const getShows = async (endpoint, showsIDs) => {
   let data;
   try {
-
     const promises = [];
-
     const fetches = [];
     for (let i = 0; i < showsIDs.length; i += 1) {
       const url = `${endpoint}/${showsIDs[i]}`;


### PR DESCRIPTION
I added the functionality to create new likes for each tv show fetched from TVmaze API and rendered to the DOM. The new likes are saved by posting a with a fetch to another API called "Involvement API" which persists the amount per each given id. When items are displayed for the first time the API is also fetched to get all the current stored likes and listed on the DOM. 😎